### PR TITLE
docs(README): add required 'libpq-dev' system dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ installed.
 $ sudo apt install build-essential curl
 $ sudo apt install libxml2-dev libxslt-dev python3-dev
 $ sudo apt build-dep python-matplotlib
-$ sudo apt install poppler-utils postgresql postgresql-contrib
+$ sudo apt install libpq-dev poppler-utils postgresql postgresql-contrib
 $ sudo apt install virtualenv
 ```
 


### PR DESCRIPTION
In order to compile 'psycopg2', you must first have 'libpq-dev' installed on your system.

See: https://stackoverflow.com/a/12912105/10023158